### PR TITLE
Payment reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Build Status](https://secure.travis-ci.org/sytzeloor/elfproef.png?branch=master)](http://travis-ci.org/sytzeloor/elfproef)
 
-This gem adds two validators to your arsenal:
+This gem adds three validators to your arsenal:
 
   * BsnValidator will validate Burgerservicenummers (Dutch social security numbers). It accepts both 8 and 9 digit BSN numbers.
   * BankAccountValidator will validate ING accounts (1-7 digits), and 9 or 10 digit bank account numbers using the elven-test.
+  * PaymentReferenceValidator will validate Betalingskenmerken (Dutch payment reference numbers) using a weighted modulus 11 and a length check.
 
 ## Installation
 
@@ -35,6 +36,12 @@ Using the BankAccountValidator
       validates :account_number, bank_account: true
 	end
 
+Using the PaymentReferenceValidator
+
+  class User < ActiveRecord::Base
+    validates :reference, payment_reference: true
+  end
+
 You can also use these validators without `ActiveRecord` by including `ActiveModel::Validations`.
    
     class AwesomeDutchPerson
@@ -55,6 +62,7 @@ Add the following to your locale file:
                 ATTRIBUTE:
                   invalid_bank_account: "is not a valid bank account number"
                   invalid_bsn: "is not a valid BSN"
+                  invalid_payment_reference: "is not a valid payment reference"
 
 ## Bugs / Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This gem adds three validators to your arsenal:
 
   * BsnValidator will validate Burgerservicenummers (Dutch social security numbers). It accepts both 8 and 9 digit BSN numbers.
   * BankAccountValidator will validate ING accounts (1-7 digits), and 9 or 10 digit bank account numbers using the elven-test.
-  * PaymentReferenceValidator will validate Betalingskenmerken (Dutch payment reference numbers) using a weighted modulus 11 and a length check.
+  * PaymentReferenceValidator will validate betalingskenmerken (Dutch payment reference numbers) using a weighted modulus 11 and a length check.
 
 ## Installation
 
@@ -38,9 +38,9 @@ Using the BankAccountValidator
 
 Using the PaymentReferenceValidator
 
-  class User < ActiveRecord::Base
-    validates :reference, payment_reference: true
-  end
+    class User < ActiveRecord::Base
+      validates :reference, payment_reference: true
+    end
 
 You can also use these validators without `ActiveRecord` by including `ActiveModel::Validations`.
    

--- a/lib/elfproef.rb
+++ b/lib/elfproef.rb
@@ -1,3 +1,4 @@
 require 'elfproef/version'
 require 'elfproef/bsn_validator'
 require 'elfproef/bank_account_validator'
+require 'elfproef/payment_reference_validator'

--- a/lib/elfproef/payment_reference_validator.rb
+++ b/lib/elfproef/payment_reference_validator.rb
@@ -69,13 +69,15 @@ class PaymentReferenceValidator < ::ActiveModel::EachValidator
     # Remove the first digit (check digit) from the payment reference.
     # To calculate the sum we need a 15 digit payment reference, 
     # prefix with 0 if necessary.
-    reference = number[1..-1].rjust(15,"0")
+    reference = number[1..-1].rjust(15,"0").split("")
     weights = [10,5,8,4,2,1,6,3,7,9,10,5,8,4,2]
 
     # Calculate the sum
     sum = 0
-    reference.split("").each_with_index do |char, i|
-      sum += char.to_i * (weights[i])
+    i = 0
+    while i < 15
+      sum += reference[i].to_i * weights[i]
+      i += 1
     end
     check_digit = 11 - (sum % 11)
     check_digit -= 10 if check_digit >= 10

--- a/lib/elfproef/payment_reference_validator.rb
+++ b/lib/elfproef/payment_reference_validator.rb
@@ -48,7 +48,7 @@ class PaymentReferenceValidator < ::ActiveModel::EachValidator
   #   2  for a 14-digit payment reference
   #
   def self.validate_length_digit(number)
-    number[1].to_i == number.length - (number.length > 11 ? 12 : 2)
+    number[1].chr.to_i == number.length - (number.length > 11 ? 12 : 2)
   end
 
   # Validates the check digit. This is the first digit when a payment
@@ -80,6 +80,6 @@ class PaymentReferenceValidator < ::ActiveModel::EachValidator
     check_digit = 11 - (sum % 11)
     check_digit -= 10 if check_digit >= 10
 
-    number[0].to_i == check_digit
+    number[0].chr.to_i == check_digit
   end
 end

--- a/lib/elfproef/payment_reference_validator.rb
+++ b/lib/elfproef/payment_reference_validator.rb
@@ -1,0 +1,85 @@
+require 'active_model/validator'
+require 'active_support/concern'
+
+# Validates if the specified value is a valid
+# payment reference number using a weighted modulus 11
+class PaymentReferenceValidator < ::ActiveModel::EachValidator
+  extend ActiveSupport::Concern
+
+  def validate_each(record, attribute, value)
+    unless self.class.validate_payment_reference(value, options)
+      record.errors.add(attribute, :invalid_payment_reference, options)
+    end
+  end
+
+  # Takes the payment reference number and returns true if:
+  #
+  #  * The number is exact 7 digits (no verification is possible)
+  #  * Is between 9 and 14 digits, has the correct check digit and has the correct length digit
+  #  * Is exact 16 digits and has the correct check digit
+  #
+  def self.validate_payment_reference(value, options = {})
+    number = value.to_s.gsub(/\D/, '').strip
+
+    # Not valid if payment reference length is < 7, 8, 15 or > 16
+    return false if number.length < 7 || number.length == 8 || number.length == 15 || number.length > 16
+
+    # No further verification possible for 7 digit payment references
+    return true if number.length == 7
+
+    # For payment references between 9 and 14 digits validate it has the correct length digit
+    self.validate_length_digit(number) if (9..14).include?(number.length)
+
+    # Validate the check digit
+    self.validate_check_digit(number)
+  end
+
+  private
+
+  # Validates the length digit. This is the second digit when 
+  # a payment reference is between 9 and 14 digits
+  #
+  # Possible values:
+  #   7  for a  9-digit payment reference
+  #   8  for a 10-digit payment reference
+  #   9  for a 11-digit payment reference
+  #   0  for a 12-digit payment reference
+  #   1  for a 13-digit payment reference
+  #   2  for a 14-digit payment reference
+  #
+  def self.validate_length_digit(number)
+    number[1].to_i == number.length - (number.length > 11 ? 12 : 2)
+  end
+
+  # Validates the check digit. This is the first digit when a payment
+  # reference is between 9 and 14 digits or is exact 16 digits
+  #
+  # The check digit is calculated using a weighted modulus 11:
+  #
+  #   c123456789012345
+  #    ABCDEFGHIJKLMNO
+  #
+  #   sum = 10*A + 5*B + 8*C + 4*D + 2*E + 1*F + 6*G + 3*H + 7*I + 9*J + 10*K + 5*L + 8*M + 4*N + 2*O
+  #   c = 11 - (sum % 11)
+  #
+  # The check digit is equal to c, with two exceptions. The check digit is
+  #   0 when c == 10
+  #   1 when c == 11
+  def self.validate_check_digit(number)
+    # Remove the first digit (check digit) from the payment reference.
+    # To calculate the sum we need a 15 digit payment reference, 
+    # prefix with 0 if necessary.
+    reference = number[1..-1].rjust(15,"0")
+    weights = [10,5,8,4,2,1,6,3,7,9,10,5,8,4,2]
+
+    # Calculate the sum
+    sum = 0
+    reference.split("").each_with_index do |char, i|
+      sum += char.to_i * (weights[i])
+    end
+    check_digit = 11 - (sum % 11)
+    check_digit -= 10 if check_digit >= 10
+
+    number[0].to_i == check_digit
+  end
+end

--- a/spec/payment_reference_validator_spec.rb
+++ b/spec/payment_reference_validator_spec.rb
@@ -1,0 +1,77 @@
+require File.dirname(__FILE__) + '/spec_helper'
+
+class PaymentReferenceTest
+  include ActiveModel::Validations
+  attr_accessor :reference
+  validates :reference, :payment_reference => true
+end
+
+describe PaymentReferenceValidator do
+  subject {
+    PaymentReferenceTest.new
+  }
+
+  it "accepts 7 digit payment references" do
+    subject.reference = "1234567"
+    subject.should be_valid
+  end
+
+  it "accepts 9 digit payment references" do
+    subject.reference = "173456789"
+    subject.should be_valid
+  end
+
+  it "accepts 10 digit payment references" do
+    subject.reference = "5834567890"
+    subject.should be_valid
+  end
+
+  it "accepts 11 digit payment references" do
+    subject.reference = "79345678901"
+    subject.should be_valid
+  end
+
+  it "accepts 12 digit payment references" do
+    subject.reference = "603456789012"
+    subject.should be_valid
+  end
+
+  it "accepts 13 digit payment references" do
+    subject.reference = "2134567890123"
+    subject.should be_valid
+  end
+
+  it "accepts 14 digit payment references" do
+    subject.reference = "02345678901234"
+    subject.should be_valid
+  end
+
+  it "accepts 16 digit payment references" do
+    subject.reference = "5000056789012345"
+    subject.should be_valid
+  end
+
+  it "rejects on an 6 payment references" do
+    subject.reference = "123456"
+    subject.should_not be_valid
+    subject.errors[:reference].should be_present
+  end
+
+  it "rejects on an 8 payment references" do
+    subject.reference = "12345678"
+    subject.should_not be_valid
+    subject.errors[:reference].should be_present
+  end
+
+  it "rejects on an 15 payment references" do
+    subject.reference = "123456789012345"
+    subject.should_not be_valid
+    subject.errors[:reference].should be_present
+  end
+
+  it "rejects on obviously wrong numbers" do
+    subject.reference = "CHUCKNORRIS"
+    subject.should_not be_valid
+    subject.errors[:reference].should be_present
+  end
+end


### PR DESCRIPTION
I've added a PaymentReferenceValidator for validating the payment reference (betalingskenmerk). I've used the validation calculations from [Specificaties van de acceptgiro](http://www.acceptgiro.nl/Downloads/Cu_RR_Ac_BijlageG_Formspecs.pdf).
