### PR TITLE
Using old Postbank account numbers as integer the validation should succeed

### DIFF
--- a/lib/elfproef/bank_account_validator.rb
+++ b/lib/elfproef/bank_account_validator.rb
@@ -18,7 +18,8 @@ class BankAccountValidator < ::ActiveModel::EachValidator
   #  * Is 9 or 10 digits and passes the 11-test
   #
   def self.validate_account_number(value, options = {})
-    number = value.to_s.gsub(/\D/, '').strip
+    value  = value.to_s
+    number = value.gsub(/\D/, '').strip
     # Not valid if length is 0, 8 or > 10
     return false if number.length == 0 || number.length == 8 || (value.length > 10 && value.length < 15) || value.length > 31
 

--- a/spec/bank_account_validator_spec.rb
+++ b/spec/bank_account_validator_spec.rb
@@ -11,6 +11,11 @@ describe BankAccountValidator do
     BankAccountTest.new
   }
 
+  it "accepts 1 digit ING accounts used as integer" do
+    subject.account = 1
+    subject.should be_valid
+  end
+
   it "accepts 1 digit ING accounts" do
     subject.account = "1"
     subject.should be_valid
@@ -88,6 +93,12 @@ describe BankAccountValidator do
 
   it "rejects on an 8 digit number" do
     subject.account = "12345678"
+    subject.should_not be_valid
+    subject.errors[:account].should be_present
+  end
+
+  it "rejects on an 8 digit number as integer" do
+    subject.account = 123456789123456
     subject.should_not be_valid
     subject.errors[:account].should be_present
   end


### PR DESCRIPTION
Hi,

After updating to version 0.2.0 the validation resulted in the library throwing errors:

``` ruby
NoMethodError:
       undefined method `length' for 123456789123456:Fixnum
```

My application used old Postbank account numbers that are saved as integers. I updated the `validate_account_number` method for non-string input and added some tests for this use-case. 
