### PR TITLE
Reject bankaccounts that have comments (or any text) added in the field

### DIFF
--- a/lib/elfproef/bank_account_validator.rb
+++ b/lib/elfproef/bank_account_validator.rb
@@ -19,7 +19,7 @@ class BankAccountValidator < ::ActiveModel::EachValidator
   #
   def self.validate_account_number(value, options = {})
     value  = value.to_s
-    number = value.gsub(/\D/, '').strip
+    number = value.gsub(/^P\s?/i, '').strip
     # Not valid if length is 0, 8 or > 10
     return false if number.length == 0 || number.length == 8 || (value.length > 10 && value.length < 15) || value.length > 31
 

--- a/spec/bank_account_validator_spec.rb
+++ b/spec/bank_account_validator_spec.rb
@@ -114,4 +114,10 @@ describe BankAccountValidator do
     subject.should_not be_valid
     subject.errors[:account].should be_present
   end
+
+  it "rejects on number with comments from users" do
+    subject.account = "417164300(ABNamro)"
+    subject.should_not be_valid
+    subject.errors[:account].should be_present
+  end
 end


### PR DESCRIPTION
Hi,

This pull request removes the line that strips all non-digit from the input before validating. When a user adds something to the bankaccount, that should raise a validation error. I've made a exception for the existing case where the bankaccount is prefixed by a _P_.
